### PR TITLE
Update CentralCore.java

### DIFF
--- a/TicketingSystem/src/com/tmu/ticketmain/CentralCore.java
+++ b/TicketingSystem/src/com/tmu/ticketmain/CentralCore.java
@@ -18,7 +18,7 @@ public class CentralCore {
     private static List<TransactionStream> transactionList = new ArrayList();
     private static List<TransactionStream> buy_sell_transList = new ArrayList();
     
-    private User activeUser;
+    private static User activeUser;
     
     public static void main(String[] args) throws IOException{
         if(args.length > 0){


### PR DESCRIPTION
activeUser needs to be static because we won't instantiate a new object CentralCore to call the non static variable activeUser